### PR TITLE
V0.1.2

### DIFF
--- a/docs/source/api/piper.verbs.clean_names.rst
+++ b/docs/source/api/piper.verbs.clean_names.rst
@@ -1,6 +1,6 @@
-piper.verbs.set\_columns
+piper.verbs.clean\_names
 ========================
 
 .. currentmodule:: piper.verbs
 
-.. autofunction:: set_columns
+.. autofunction:: clean_names

--- a/docs/source/api/piper.verbs.columns.rst
+++ b/docs/source/api/piper.verbs.columns.rst
@@ -1,6 +1,0 @@
-piper.verbs.columns
-===================
-
-.. currentmodule:: piper.verbs
-
-.. autofunction:: columns

--- a/docs/source/api/piper.verbs.combine_header_rows.rst
+++ b/docs/source/api/piper.verbs.combine_header_rows.rst
@@ -1,6 +1,0 @@
-piper.verbs.combine\_header\_rows
-=================================
-
-.. currentmodule:: piper.verbs
-
-.. autofunction:: combine_header_rows

--- a/docs/source/api/piper.verbs.drop_columns.rst
+++ b/docs/source/api/piper.verbs.drop_columns.rst
@@ -1,6 +1,0 @@
-piper.verbs.drop\_columns
-=========================
-
-.. currentmodule:: piper.verbs
-
-.. autofunction:: drop_columns

--- a/docs/source/api/piper.verbs.drop_if.rst
+++ b/docs/source/api/piper.verbs.drop_if.rst
@@ -1,0 +1,6 @@
+piper.verbs.drop\_if
+====================
+
+.. currentmodule:: piper.verbs
+
+.. autofunction:: drop_if

--- a/docs/source/api/piper.verbs.flatten_cols.rst
+++ b/docs/source/api/piper.verbs.flatten_cols.rst
@@ -1,6 +1,0 @@
-piper.verbs.flatten\_cols
-=========================
-
-.. currentmodule:: piper.verbs
-
-.. autofunction:: flatten_cols

--- a/docs/source/api/piper.verbs.flatten_names.rst
+++ b/docs/source/api/piper.verbs.flatten_names.rst
@@ -1,6 +1,6 @@
-piper.verbs.clean\_columns
+piper.verbs.flatten\_names
 ==========================
 
 .. currentmodule:: piper.verbs
 
-.. autofunction:: clean_columns
+.. autofunction:: flatten_names

--- a/docs/source/api/piper.verbs.names.rst
+++ b/docs/source/api/piper.verbs.names.rst
@@ -1,0 +1,6 @@
+piper.verbs.names
+=================
+
+.. currentmodule:: piper.verbs
+
+.. autofunction:: names

--- a/docs/source/api/piper.verbs.replace_columns.rst
+++ b/docs/source/api/piper.verbs.replace_columns.rst
@@ -1,6 +1,0 @@
-piper.verbs.replace\_columns
-============================
-
-.. currentmodule:: piper.verbs
-
-.. autofunction:: replace_columns

--- a/docs/source/api/piper.verbs.replace_columns.rst
+++ b/docs/source/api/piper.verbs.replace_columns.rst
@@ -1,0 +1,6 @@
+piper.verbs.replace\_columns
+============================
+
+.. currentmodule:: piper.verbs
+
+.. autofunction:: replace_columns

--- a/docs/source/api/piper.verbs.replace_names.rst
+++ b/docs/source/api/piper.verbs.replace_names.rst
@@ -1,0 +1,6 @@
+piper.verbs.replace\_names
+==========================
+
+.. currentmodule:: piper.verbs
+
+.. autofunction:: replace_names

--- a/docs/source/api/piper.verbs.rows_to_columns.rst
+++ b/docs/source/api/piper.verbs.rows_to_columns.rst
@@ -1,6 +1,0 @@
-piper.verbs.rows\_to\_columns
-=============================
-
-.. currentmodule:: piper.verbs
-
-.. autofunction:: rows_to_columns

--- a/docs/source/api/piper.verbs.rows_to_columns.rst
+++ b/docs/source/api/piper.verbs.rows_to_columns.rst
@@ -1,0 +1,6 @@
+piper.verbs.rows\_to\_columns
+=============================
+
+.. currentmodule:: piper.verbs
+
+.. autofunction:: rows_to_columns

--- a/docs/source/api/piper.verbs.rows_to_names.rst
+++ b/docs/source/api/piper.verbs.rows_to_names.rst
@@ -1,0 +1,6 @@
+piper.verbs.rows\_to\_names
+===========================
+
+.. currentmodule:: piper.verbs
+
+.. autofunction:: rows_to_names

--- a/docs/source/api/piper.verbs.set_names.rst
+++ b/docs/source/api/piper.verbs.set_names.rst
@@ -1,0 +1,6 @@
+piper.verbs.set\_names
+======================
+
+.. currentmodule:: piper.verbs
+
+.. autofunction:: set_names

--- a/docs/source/api/piper.verbs.str_clean_number.rst
+++ b/docs/source/api/piper.verbs.str_clean_number.rst
@@ -1,0 +1,6 @@
+piper.verbs.str\_clean\_number
+==============================
+
+.. currentmodule:: piper.verbs
+
+.. autofunction:: str_clean_number

--- a/docs/source/verbs.rst
+++ b/docs/source/verbs.rst
@@ -37,10 +37,11 @@ column management
    :toctree: api
 
    columns
+   flatten_cols
    relocate
    rename
+   rows_to_columns
    set_columns
-   combine_header_rows
 
 data cleaning
 -------------
@@ -53,7 +54,6 @@ data cleaning
    drop_columns
    drop
    duplicated
-   flatten_cols
    overlaps
    non_alpha
 

--- a/docs/source/verbs.rst
+++ b/docs/source/verbs.rst
@@ -43,6 +43,7 @@ column management
    flatten_cols
    relocate
    rename
+   replace_columns
    rows_to_columns
    set_columns
 
@@ -72,6 +73,7 @@ string functions
 .. autosummary::
    :toctree: api
 
+   str_clean_number
    str_join
    str_split
    str_trim

--- a/docs/source/verbs.rst
+++ b/docs/source/verbs.rst
@@ -36,16 +36,16 @@ column management
 .. autosummary::
    :toctree: api
 
-   clean_columns
-   columns
+   clean_names
+   names
    drop
    drop_if
-   flatten_cols
+   flatten_names
    relocate
    rename
-   replace_columns
-   rows_to_columns
-   set_columns
+   replace_names
+   rows_to_names
+   set_names
 
 data cleaning
 -------------

--- a/docs/source/verbs.rst
+++ b/docs/source/verbs.rst
@@ -36,7 +36,10 @@ column management
 .. autosummary::
    :toctree: api
 
+   clean_columns
    columns
+   drop
+   drop_if
    flatten_cols
    relocate
    rename
@@ -49,10 +52,7 @@ data cleaning
 .. autosummary::
    :toctree: api
 
-   clean_columns
    distinct
-   drop_columns
-   drop
    duplicated
    overlaps
    non_alpha

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,12 @@
 
 mypy_path = 'piper/*.py'
 
+[mypy-nbformat.*]
+ignore_missing_imports = True
+
+[mypy-nbconvert.*]
+ignore_missing_imports = True
+
 [mypy-pandas.*]
 ignore_missing_imports = True
 

--- a/piper/defaults.py
+++ b/piper/defaults.py
@@ -33,3 +33,4 @@ ip = register_magic()
 
 pd.set_option("display.max_columns", 80)
 pd.set_option('max_colwidth', 120)
+pd.set_option('display.precision', 6)

--- a/piper/io.py
+++ b/piper/io.py
@@ -487,8 +487,7 @@ def read_excel_sheets(filename = None,
                 if info:
                     logger.info(f'sheet: {sheet}, (rows, cols) {dx.shape}')
 
-                if return_type == 'list_frames' or \
-                   return_type == 'combine':
+                if return_type == 'list_frames' or return_type == 'combine':
                     dataframes.append(dx)
 
                 elif return_type == 'dataframes':

--- a/piper/io.py
+++ b/piper/io.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from piper.decorators import shape
 from piper.text import _file_with_ext
 from piper.text import _get_qual_file
-from piper.verbs import clean_columns
+from piper.verbs import clean_names
 from piper.verbs import str_trim
 from zipfile import ZipFile, ZIP_DEFLATED
 from piper.xl import WorkBook
@@ -229,7 +229,7 @@ def read_csv(file_name: str,
         df = str_trim(df)
 
     if clean_cols:
-        df = clean_columns(df)
+        df = clean_names(df)
 
     return df
 
@@ -281,7 +281,7 @@ def read_csvs(source = 'inputs/',
                 logger.info(f'Warning: Dataframe strip_blanks = {strip_blanks}')
 
         if clean_cols:
-            dx = clean_columns(dx)
+            dx = clean_names(dx)
 
         if include_file:
             dx['filename'] = file_.name
@@ -346,7 +346,7 @@ def read_excels(source = 'inputs/',
             df = df.iloc[2:]
 
             # clean up column names to make it easier to use them in calculations
-            df = clean_columns(df)
+            df = clean_names(df)
 
             # Set date data types for order and ship dates
             cols = ['order_date', 'ship_date']
@@ -380,7 +380,7 @@ def read_excels(source = 'inputs/',
                     .drop(columns=['ship_mode_container'])
                     .pipe(move_column, 'days_to_ship', 'after', 'ship_date')
                     .pipe(move_column, 'sales_amount', 'after', 'unit_sell_price')
-                    .pipe(clean_columns, replace_char=('_', ' '), title=True)
+                    .pipe(clean_names, replace_char=('_', ' '), title=True)
                  )
 
             return df
@@ -545,7 +545,7 @@ def read_sql(sql,
     '''
     try:
         df = pd.read_sql(sql, con=con)
-        df = clean_columns(df)
+        df = clean_names(df)
     except cx_Oracle.DatabaseError as e:
         logger.info(e)
 

--- a/piper/nb.py
+++ b/piper/nb.py
@@ -1,4 +1,4 @@
-from nbconvert.preprocessors import CellExecutionError
+from nbconvert.preprocessors import CellExecutionError 
 from nbconvert.preprocessors import ExecutePreprocessor
 from pathlib import Path
 from piper.io import list_files
@@ -130,8 +130,8 @@ def create_nb_folders(project: str = 'project',
 
 
 # execute_notebook {{{1
-def execute_notebook(input_file: str,
-                     output_file: str) -> Dict:
+def execute_notebook(input_file: Path,
+                     output_file: Path) -> Dict:
     ''' Execute notebook within a folder
 
 

--- a/piper/odbc.py
+++ b/piper/odbc.py
@@ -11,55 +11,10 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def connections(file_name=None, return_type='dataframe'):
-    ''' get all available defined database environments
-
-    Parameters
-    ----------
-    file_name
-        json formatted connections file (similar to tnsnames.ora)
-        if None (default) uses ../src/config.json
-    return type
-        return object type: 'dataframe'(default) 'dictionary'
-
-    Returns
-    -------
-    dictionary or dataframe
-
-    Examples
-    --------
-
-    .. code-block::
-
-        df = connections(return_type='dataframe')
-        dict_config = connections(return_type='dictionary')
-
-    '''
-    if file_name == None:
-        default_config = get_config('config.json')
-        file_name = default_config['connections']['location']
-
-    config = get_config(file_name, info=False)
-    logger.debug(config)
-
-    if return_type == 'dictionary':
-        return config
-
-    if return_type == 'dataframe':
-        df = (pd.DataFrame(config).T).fillna('')
-
-        if 'pw' in df.columns:
-           df = df.drop(columns=['pw'])
-
-        lowercase_cols = ['schema', 'sid', 'user']
-        for col in lowercase_cols:
-            if col in df.columns:
-                df[col] = df[col].str.lower()
-
-    return df
-
-
-def connect(connection=None, connection_type=None, file_name=None):
+# connect {{{1
+def connect(connection = None,
+            connection_type = None,
+            file_name = None):
     ''' Return database connection
 
     Examples
@@ -115,6 +70,57 @@ def connect(connection=None, connection_type=None, file_name=None):
         return con, schema, schema_ctl
 
 
+# connections {{{1
+def connections(file_name = None,
+                return_type = 'dataframe'):
+    ''' get all available defined database environments
+
+    Parameters
+    ----------
+    file_name
+        json formatted connections file (similar to tnsnames.ora)
+        if None (default) uses ../src/config.json
+    return type
+        return object type: 'dataframe'(default) 'dictionary'
+
+    Returns
+    -------
+    dictionary or dataframe
+
+    Examples
+    --------
+
+    .. code-block::
+
+        df = connections(return_type='dataframe')
+        dict_config = connections(return_type='dictionary')
+
+    '''
+    if file_name == None:
+        default_config = get_config('config.json')
+        file_name = default_config['connections']['location']
+
+    config = get_config(file_name, info=False)
+    logger.debug(config)
+
+    if return_type == 'dictionary':
+        return config
+
+    if return_type == 'dataframe':
+        df = (pd.DataFrame(config).T).fillna('')
+
+        if 'pw' in df.columns:
+           df = df.drop(columns=['pw'])
+
+        lowercase_cols = ['schema', 'sid', 'user']
+        for col in lowercase_cols:
+            if col in df.columns:
+                df[col] = df[col].str.lower()
+
+    return df
+
+
+# _get_iseries_con {{{1
 def _get_iseries_con(connection_parms):
     ''' Return ibm connection for given system.
 
@@ -148,6 +154,7 @@ def _get_iseries_con(connection_parms):
     return con
 
 
+# _get_postgres_con {{{1
 def _get_postgres_con(connection_parms):
     ''' Return postgres connection for given system.
 
@@ -178,6 +185,7 @@ def _get_postgres_con(connection_parms):
     return con
 
 
+# _get_oracle_con {{{1
 def _get_oracle_con(connection_parms='JDE8EPA'):
     ''' Return Oracle connection and schema, schema_ctl.
 

--- a/piper/test/test_verbs.py
+++ b/piper/test/test_verbs.py
@@ -417,14 +417,14 @@ def test_columns_as_regex(t_sample_data):
     assert expected == actual
 
 
-# test_rows_to_columns {{{1
+# test_rows_to_columns_with_title {{{1
 def test_rows_to_columns_with_title():
 
     data = {'A': ['Order', 'Qty', 10, 40],
             'B': ['Order', 'Number', 12345, 12346]}
 
     df = pd.DataFrame(data)
-    df = rows_to_columns(df, delimitter=' ', title=True)
+    df = rows_to_columns(df, delimitter=' ')
 
     expected = ['Order Qty', 'Order Number']
     actual = df.columns.to_list()
@@ -432,29 +432,14 @@ def test_rows_to_columns_with_title():
     assert expected == actual
 
 
-# test_rows_to_columns_lower {{{1
-def test_rows_to_columns_lower():
-
-    data = {'A': ['Order', 'Qty', 10, 40],
-            'B': ['Order', 'Number', 12345, 12346]}
-
-    df = pd.DataFrame(data)
-    df = rows_to_columns(df, delimitter=' ', title=False)
-
-    expected = ['order qty', 'order number']
-    actual = df.columns.to_list()
-
-    assert expected == actual
-
-
-# test_rows_to_columns_title {{{1
+# test_rows_to_columns_title_bad_data {{{1
 def test_rows_to_columns_title_bad_data():
 
     data = {'A': ['Order   ', 'Qty   ', 10, 40],
             'B': [' Order', '    Number%', 12345, 12346]}
 
     df = pd.DataFrame(data)
-    df = rows_to_columns(df, delimitter=' ', title=True)
+    df = rows_to_columns(df, delimitter=' ')
 
     expected = ['Order Qty', 'Order Number']
     actual = df.columns.to_list()

--- a/piper/test/test_verbs.py
+++ b/piper/test/test_verbs.py
@@ -108,6 +108,19 @@ def test_across_single_column_series_object_function(t_sample_data):
     assert pd.api.types.is_float_dtype(df.values_1)
 
 
+# test_across_tuple_column_series_object_function {{{1
+def test_across_tuple_column_series_object_function(t_sample_data):
+
+    df = t_sample_data
+
+    df = across(df, columns=('values_1', 'values_2'),
+                function= lambda x: x.astype(float),
+                series_obj=True)
+
+    assert pd.api.types.is_float_dtype(df.values_1)
+    assert pd.api.types.is_float_dtype(df.values_2)
+
+
 # test_across_list_column_series_object_function {{{1
 def test_across_list_column_series_object_function(t_sample_data):
 
@@ -631,6 +644,20 @@ def test_drop_if(t_dummy_dataframe):
     assert expected == actual
 
 
+# test_drop_if_isna {{{1
+def test_drop_if_isna(t_dummy_dataframe):
+    """
+    """
+    df = t_dummy_dataframe
+
+    expected = (5, 5)
+    df.loc[:, 'blank_1': 'blank_5'] = np.nan
+    df = drop_if(df, value='isna')
+    actual = df.shape
+
+    assert expected == actual
+
+
 # test_duplicated {{{1
 def test_duplicated(t_simple_series_01):
     """
@@ -838,6 +865,19 @@ def test_head_with_columns_function(t_sample_data):
         astype='list')]).shape
 
     assert expected == actual
+
+
+# test_head_with_tablefmt_plain {{{1
+def test_head_with_tablefmt_plain(t_dummy_dataframe):
+    """
+    """
+    df = t_dummy_dataframe
+
+    df.loc[:, 'blank_1': 'blank_5'] = np.nan
+    df = drop_if(df, value='isna')
+    result = head(df, tablefmt='plain')
+    assert result == None
+
 
 # test_info {{{1
 def test_info(t_simple_series_01):
@@ -1520,6 +1560,46 @@ def test_set_columns():
 
     assert expected == actual
 
+# test_str_join_str_column_raise_columns_list_error {{{1
+def test_str_join_str_column_raise_columns_list_error(t_sample_sales):
+
+    df = t_sample_sales
+
+    with pytest.raises(NameError):
+        actual = str_join(df, columns='actual_sales',
+                          sep='|', column='combined_col', drop=False)
+
+
+# test_str_join_str_column_raise_column_must_be_string_error {{{1
+def test_str_join_str_column_raise_column_must_be_string_error(t_sample_sales):
+
+    df = t_sample_sales
+
+    with pytest.raises(TypeError):
+        actual = str_join(df, columns=['actual_sales', 'product'],
+                          sep='|', column=['combined_col'], drop=False)
+
+
+# test_str_join_str_column_raise_at_least_two_columns_error {{{1
+def test_str_join_str_column_raise_at_least_two_columns_error(t_sample_sales):
+
+    df = t_sample_sales
+
+    with pytest.raises(ValueError):
+        actual = str_join(df, columns=['actual_sales'],
+                          sep='|', column='combined_col', drop=False)
+
+
+# test_str_join_str_column_raise_check_columns_name_error {{{1
+def test_str_join_str_column_raise_check_columns_name_error(t_sample_sales):
+
+    df = t_sample_sales
+
+    with pytest.raises(NameError):
+        actual = str_join(df, columns=['actual_sales', 'product_wrong'],
+                          sep='|', column='combined_col', drop=False)
+
+
 # test_str_join_str_column_drop_false {{{1
 def test_str_join_str_column_drop_false(t_sample_sales):
 
@@ -1701,6 +1781,18 @@ def test_tail_with_dataframe(t_sample_data):
     expected = (4, 7)
     actual = tail(df).shape
     assert expected == actual
+
+
+# test_tail_with_tablefmt_plain {{{1
+def test_tail_with_tablefmt_plain(t_dummy_dataframe):
+    """
+    """
+    df = t_dummy_dataframe
+
+    df.loc[:, 'blank_1': 'blank_5'] = np.nan
+    df = drop_if(df, value='isna')
+    result = tail(df, tablefmt='plain')
+    assert result == None
 
 
 # test_transform {{{1

--- a/piper/test/test_verbs.py
+++ b/piper/test/test_verbs.py
@@ -9,7 +9,7 @@ from piper.verbs import adorn
 from piper.verbs import assign
 from piper.verbs import clean_columns
 from piper.verbs import columns
-from piper.verbs import combine_header_rows
+from piper.verbs import rows_to_columns
 from piper.verbs import count
 from piper.verbs import distinct
 from piper.verbs import drop
@@ -291,21 +291,22 @@ def test_assign_with_value_error(t_sample_data):
         actual = assign(df, reversed=lambda x: x[::-1])
 
 
-# test_clean_column_list_using_list_and_title {{{1
-def test_clean_column_list_using_list_and_title(get_column_list):
+# test_clean_columns_report_case_with_title {{{1
+def test_clean_columns_report_case_with_title(get_column_list):
     """
     """
-    expected = ['Dupe', 'Customer', 'Mdm_No_To_Use', 'Target_Name', 'Public',
-                'Material', 'Prod_Type', 'Effective', 'Expired',
+    expected = ['Dupe', 'Customer', 'Mdm No To Use', 'Target Name', 'Public',
+                'Material', 'Prod Type', 'Effective', 'Expired',
                 'Price', 'Currency']
 
     dx = pd.DataFrame(None, columns=get_column_list)
 
-    actual = clean_columns(dx, title=True).columns.tolist()
+    actual = clean_columns(dx, case='report', title=True).columns.tolist()
     assert expected == actual
 
-# test_clean_column_list_using_df_columns {{{1
-def test_clean_column_list_using_df_columns(get_column_list):
+
+# test_clean_columns_snake_case_with_title {{{1
+def test_clean_columns_snake_case_with_title(get_column_list):
     """
     """
     expected = ['dupe', 'customer', 'mdm_no_to_use', 'target_name', 'public',
@@ -314,7 +315,36 @@ def test_clean_column_list_using_df_columns(get_column_list):
 
     dx = pd.DataFrame(None, columns=get_column_list)
 
-    actual = clean_columns(dx).columns.tolist()
+    actual = clean_columns(dx, case='snake').columns.tolist()
+
+    assert expected == actual
+
+
+# test_clean_columns_camel_case_with_title {{{1
+def test_clean_columns_camel_case_with_title(get_column_list):
+    """
+    """
+    expected = ['Dupe', 'Customer', 'MdmNoToUse', 'TargetName', 'Public',
+                'Material', 'ProdType', 'Effective', 'Expired', 'Price', 'Currency']
+
+    dx = pd.DataFrame(None, columns=get_column_list)
+
+    actual = clean_columns(dx, case='camel', title=True).columns.tolist()
+
+    assert expected == actual
+
+
+# test_clean_columns_camel_case_without_title {{{1
+def test_clean_columns_camel_case_without__title(get_column_list):
+    """
+    """
+    expected = ['dupe', 'customer', 'mdmNoToUse', 'targetName', 'public',
+                'material', 'prodType', 'effective', 'expired', 'price', 'currency']
+
+    dx = pd.DataFrame(None, columns=get_column_list)
+
+    actual = clean_columns(dx, case='camel', title=False).columns.tolist()
+
     assert expected == actual
 
 
@@ -371,14 +401,14 @@ def test_columns_as_regex(t_sample_data):
     assert expected == actual
 
 
-# test_combine_header_rows {{{1
-def test_combine_header_rows_with_title():
+# test_rows_to_columns {{{1
+def test_rows_to_columns_with_title():
 
     data = {'A': ['Order', 'Qty', 10, 40],
             'B': ['Order', 'Number', 12345, 12346]}
 
     df = pd.DataFrame(data)
-    df = combine_header_rows(df, title=True)
+    df = rows_to_columns(df, delimitter=' ', title=True)
 
     expected = ['Order Qty', 'Order Number']
     actual = df.columns.to_list()
@@ -386,14 +416,14 @@ def test_combine_header_rows_with_title():
     assert expected == actual
 
 
-# test_combine_header_rows_lower {{{1
-def test_combine_header_rows_lower():
+# test_rows_to_columns_lower {{{1
+def test_rows_to_columns_lower():
 
     data = {'A': ['Order', 'Qty', 10, 40],
             'B': ['Order', 'Number', 12345, 12346]}
 
     df = pd.DataFrame(data)
-    df = combine_header_rows(df, title=False)
+    df = rows_to_columns(df, delimitter=' ', title=False)
 
     expected = ['order qty', 'order number']
     actual = df.columns.to_list()
@@ -401,14 +431,14 @@ def test_combine_header_rows_lower():
     assert expected == actual
 
 
-# test_combine_header_rows_title {{{1
-def test_combine_header_rows_title_bad_data():
+# test_rows_to_columns_title {{{1
+def test_rows_to_columns_title_bad_data():
 
     data = {'A': ['Order   ', 'Qty   ', 10, 40],
             'B': [' Order', '    Number%', 12345, 12346]}
 
     df = pd.DataFrame(data)
-    df = combine_header_rows(df, title=True)
+    df = rows_to_columns(df, delimitter=' ', title=True)
 
     expected = ['Order Qty', 'Order Number']
     actual = df.columns.to_list()

--- a/piper/test/test_verbs.py
+++ b/piper/test/test_verbs.py
@@ -13,7 +13,7 @@ from piper.verbs import rows_to_columns
 from piper.verbs import count
 from piper.verbs import distinct
 from piper.verbs import drop
-from piper.verbs import drop_columns
+from piper.verbs import drop_if
 from piper.verbs import duplicated
 from piper.verbs import explode
 from piper.verbs import flatten_cols
@@ -619,14 +619,14 @@ def test_drop(t_sample_data):
     assert expected == actual
 
 
-# test_drop_columns {{{1
-def test_drop_columns(t_dummy_dataframe):
+# test_drop_if {{{1
+def test_drop_if(t_dummy_dataframe):
     """
     """
     df = t_dummy_dataframe
 
     expected = (5, 5)
-    actual = drop_columns(df).shape
+    actual = drop_if(df).shape
 
     assert expected == actual
 

--- a/piper/test/test_verbs.py
+++ b/piper/test/test_verbs.py
@@ -31,12 +31,12 @@ from piper.verbs import pivot_table
 from piper.verbs import relocate
 from piper.verbs import rename
 from piper.verbs import rename_axis
+from piper.verbs import replace_columns
 from piper.verbs import right_join
 from piper.verbs import sample
 from piper.verbs import select
 from piper.verbs import set_columns
 from piper.verbs import str_clean_number
-from piper.verbs import str_columns_replace
 from piper.verbs import str_split
 from piper.verbs import str_trim
 from piper.verbs import summarise
@@ -1285,6 +1285,26 @@ def test_rename_axis(t_sample_data):
     assert expected == actual
 
 
+
+
+# test_replace_columns {{{1
+def test_replace_columns():
+
+    dict_ = {'number$': 'nbr', 'revenue per cookie': 'unit revenue',
+             'cost per cookie': 'unit cost', 'month': 'mth',
+             'revenue per cookie': 'unit revenue', 'product': 'item', 'year': 'yr'}
+
+    cols = ['Country', 'Product', 'Units Sold', 'Revenue per cookie', 'Cost per cookie',
+            'Revenue', 'Cost', 'Profit', 'Date', 'Month Number', 'Month Name', 'Year']
+
+    expected = ['country','item', 'units_sold', 'unit_revenue', 'unit_cost',
+                'revenue', 'cost', 'profit', 'date', 'mth_nbr', 'mth_name', 'yr']
+
+    df = pd.DataFrame(None, columns=cols)
+    df = replace_columns(df, dict_, info=True)
+    df = clean_columns(df)
+
+    assert expected == list(df.columns)
 # test_resample_groupby {{{1
 def test_resample_groupby(t_sample_data):
     """ """
@@ -1577,26 +1597,6 @@ def test_str_clean_number():
     df['values'] = str_clean_number(df['values'])
 
     assert expected == df['values'].values.tolist()
-
-
-# test_str_columns_replace {{{1
-def test_str_columns_replace():
-
-    dict_ = {'number$': 'nbr', 'revenue per cookie': 'unit revenue',
-             'cost per cookie': 'unit cost', 'month': 'mth',
-             'revenue per cookie': 'unit revenue', 'product': 'item', 'year': 'yr'}
-
-    cols = ['Country', 'Product', 'Units Sold', 'Revenue per cookie', 'Cost per cookie',
-            'Revenue', 'Cost', 'Profit', 'Date', 'Month Number', 'Month Name', 'Year']
-
-    expected = ['country','item', 'units_sold', 'unit_revenue', 'unit_cost',
-                'revenue', 'cost', 'profit', 'date', 'mth_nbr', 'mth_name', 'yr']
-
-    df = pd.DataFrame(None, columns=cols)
-    df = str_columns_replace(df, dict_, info=True)
-    df = clean_columns(df)
-
-    assert expected == list(df.columns)
 
 
 # test_str_join_str_column_raise_columns_list_error {{{1

--- a/piper/test/test_verbs.py
+++ b/piper/test/test_verbs.py
@@ -1841,6 +1841,36 @@ def test_str_split_number_column_drop_true_expand_True(t_sample_sales):
     assert actual.loc[4:4, 'number'].values[0] == '29209'
 
 
+# test_str_split_number_raise_type_error_column_str {{{1
+def test_str_split_number_raise_type_error_column_str(t_sample_sales):
+
+    df = t_sample_sales
+
+    with pytest.raises(TypeError):
+        actual = str_split(df, ['actual_sales'], columns=['number', 'precision'],
+                       pat='.', drop=True, expand=True)
+
+
+# test_str_split_number_raise_type_error_columns_list_like {{{1
+def test_str_split_number_raise_type_error_columns_list_like(t_sample_sales):
+
+    df = t_sample_sales
+
+    with pytest.raises(TypeError):
+        actual = str_split(df, 'actual_sales', columns='number',
+                       pat='.', drop=True, expand=True)
+
+
+# test_str_split_number_raise_name_error_column_in_list {{{1
+def test_str_split_number_raise_name_error_column_in_list(t_sample_sales):
+
+    df = t_sample_sales
+
+    with pytest.raises(NameError):
+        actual = str_split(df, 'actual_sales_wrong', columns=['number', 'precision'],
+                       pat='.', drop=True, expand=True)
+
+
 # test_str_trim_blanks {{{1
 def test_str_trim_blanks(t_sample_column_clean_text):
     """
@@ -1945,12 +1975,23 @@ def test_tail_with_tablefmt_plain(t_dummy_dataframe):
     assert result == None
 
 
+# test_transform_no_parms {{{1
+def test_transform_no_parms(t_sample_sales):
+    """ """
+
+    df = t_sample_sales
+    df = group_by(df, ['product', 'location'])
+    df = summarise(df)
+    df = transform(df)
+    df = where(df, "product == 'Beachwear'")
+    actual = select(df, "g%").values[0][0]
+
+    assert 32.58 == actual
+
+
 # test_transform {{{1
 def test_transform(t_sample_data):
-    """
-
-
-    """
+    """ """
 
     index = ['countries', 'regions']
     cols = ['countries', 'regions', 'ids', 'values_1', 'values_2']

--- a/piper/text.py
+++ b/piper/text.py
@@ -294,7 +294,7 @@ def pipe_function_parms(idx: int, value: str) -> str:
 
 
 # paste() {{{1
-def paste(source='text'):
+def paste(source='vertical'):
     ''' Convert a clipboard sourced list from text or excel file
 
     Examples
@@ -313,15 +313,20 @@ def paste(source='text'):
     -------
     Clipboard contents
     '''
+
     if source == 'vertical':
         dx = pd.read_clipboard(header=None, names=['x'])
-        data = "['" + "', '".join(dx.x.values.tolist()) + "']"
 
-    if source == 'horizontal':
+        # make sure no apostrophe's copied into clipboard contents by mistake
+        # dx['x'] = dx['x'].str.replace("""["']""", '', regex=True)
+
+        data = "['" + "', '".join(dx.x.astype(str).values.tolist()) + "']"
+
+    if source == 'horizontal_list':
         dx = pd.read_clipboard(sep='\t')
         data = dx.columns.tolist()
 
-    if source == 'horizontal_list':
+    if source == 'horizontal':
         dx = pd.read_clipboard(sep='\t')
         data = "['" + "', '".join(dx.columns.tolist()) + "']"
 

--- a/piper/verbs.py
+++ b/piper/verbs.py
@@ -614,19 +614,25 @@ def count(df: pd.DataFrame,
     A pandas dataframe
     '''
     # NOTE:: pd.groupby by default does not count nans!
+    f = lambda x: x.value_counts(dropna=False)
+
     try:
         if isinstance(columns, str):
-            p1 = df.groupby(columns, dropna=False).agg(totals=(columns, lambda x: x.value_counts(dropna=False)))
+            p1 = df.groupby(columns, dropna=False).agg(totals=(columns, f))
         elif isinstance(df, pd.Series):
             new_df = df.to_frame()
             columns = new_df.columns.tolist()[0]
-            p1 = new_df.groupby(columns, dropna=False).agg(totals=(columns, lambda x: x.value_counts(dropna=False)))
+            p1 = new_df.groupby(columns, dropna=False).agg(totals=(columns, f))
         elif isinstance(df, pd.DataFrame):
             if columns is not None:
-                p1 = df.groupby(columns, dropna=False).agg(totals=(columns[0], lambda x: x.value_counts(dropna=False)))
+                p1 = df.groupby(columns, dropna=False).agg(totals=(columns[0], f))
             else:
                 p1 = df.count().to_frame()
 
+    except (ValueError) as e:
+        p1 = df[columns].value_counts()
+        p1 = p1.to_frame()
+        p1.columns = ['totals']
     except (KeyError, AttributeError) as e:
         logger.info(f"Column {columns} not found!")
         return

--- a/piper/verbs.py
+++ b/piper/verbs.py
@@ -519,9 +519,9 @@ def columns(df: pd.DataFrame,
         return pd.DataFrame(cols, columns = ['column_names'])
     elif astype == 'series':
         return pd.Series(cols, name='column_names')
-
-    # note: mypy needs to see this 'dummy' catch all return statement
-    return None
+    else:
+        # note: mypy needs to see this 'dummy' catch all return statement
+        return None
 
 
 # count() {{{1
@@ -630,8 +630,7 @@ def count(df: pd.DataFrame,
                 p1 = df.count().to_frame()
 
     except (ValueError) as e:
-        p1 = df[columns].value_counts()
-        p1 = p1.to_frame()
+        p1 = df[columns].value_counts().to_frame()
         p1.columns = ['totals']
     except (KeyError, AttributeError) as e:
         logger.info(f"Column {columns} not found!")
@@ -1290,10 +1289,11 @@ def head(df: pd.DataFrame,
         _shape(df)
 
     if tablefmt:
-        print(df.head(n=n).to_markdown(tablefmt=tablefmt, floatfmt=f".{precision}f"))
-        return
-
-    return df.head(n=n)
+        print(df.head(n=n)
+                .to_markdown(tablefmt=tablefmt,
+                             floatfmt=f".{precision}f"))
+    else:
+        return df.head(n=n)
 
 
 # info() {{{1
@@ -1748,7 +1748,6 @@ def pivot_longer(df: pd.DataFrame,
     This is a wrapper function rather than using e.g. df.melt()
     For details of args, kwargs - see help(pd.DataFrame.melt)
 
-
     Parameters
     ----------
     df
@@ -1757,7 +1756,6 @@ def pivot_longer(df: pd.DataFrame,
         arguments for wrapped function
     **kwargs
         keyword-parameters for wrapped function
-
 
     Returns
     -------
@@ -2917,7 +2915,7 @@ def summarise(df: pd.DataFrame,
             return summary_
 
         # If groupby obj, assume sum function
-        if isinstance(df, pd.core.groupby.generic.DataFrameGroupBy ):
+        if isinstance(df, pd.core.groupby.generic.DataFrameGroupBy):
                 return df.agg(sum)
 
     group_df = df.agg(*args, **kwargs)
@@ -3049,10 +3047,11 @@ def tail(df: pd.DataFrame,
         _shape(df)
 
     if tablefmt:
-        print(df.tail(n=n).to_markdown(tablefmt=tablefmt, floatfmt=f".{precision}f"))
-        return
-
-    return df.tail(n=n)
+        print(df.tail(n=n)
+                .to_markdown(tablefmt=tablefmt,
+                             floatfmt=f".{precision}f"))
+    else:
+        return df.tail(n=n)
 
 
 # transform() {{{1
@@ -3136,7 +3135,6 @@ def transform(df: pd.DataFrame,
                 - rank: dense rank (ascending order)
                 - rank_desc: dense rank (descending order)
 
-
     Returns
     -------
     original dataframe with additional grouped calculation column
@@ -3168,8 +3166,7 @@ def transform(df: pd.DataFrame,
         # If no kwargs passed, default to group % on
         # first column in dataframe
         column, value = 'g%', df.columns[0]
-        func = check_builtin('percent')
-        df[column] = df.groupby(index)[value].transform(func)
+        df[column] = df.groupby(index)[value].transform(check_builtin('percent'))
 
     return df
 

--- a/piper/verbs.py
+++ b/piper/verbs.py
@@ -248,7 +248,7 @@ def adorn(df: pd.DataFrame,
 
         g1 = df.groupby(['Type', 'Region']).agg(TotalSales=('Sales', 'sum')).unstack()
         g1 = adorn(g1, axis='both').astype(int)
-        g1 = flatten_cols(g1, remove_prefix='TotalSales')
+        g1 = flatten_names(g1, remove_prefix='TotalSales')
         g1
 
                                   East     North     South     West      All
@@ -455,77 +455,6 @@ def assign(df: pd.DataFrame,
     return df
 
 
-# columns() {{{1
-def columns(df: pd.DataFrame,
-            regex: str = None,
-            astype: str = 'list') -> Union[str, list, dict, pd.Series, pd.DataFrame]:
-    '''show dataframe column information
-
-    This function is useful reviewing or manipulating column(s)
-
-    The dictionary output is particularly useful when composing the rename of
-    multiple columns.
-
-    Examples
-    --------
-
-    .. code-block::
-
-        import numpy as np
-        import pandas as pd
-
-        id_list = ['A', 'B', 'C', 'D', 'E']
-        s1 = pd.Series(np.random.choice(id_list, size=5), name='ids')
-
-        region_list = ['East', 'West', 'North', 'South']
-        s2 = pd.Series(np.random.choice(region_list, size=5), name='regions')
-
-        df = pd.concat([s1, s2], axis=1)
-
-        columns(df, 'list')
-
-        ['ids', 'regions']
-
-
-    Parameters
-    ----------
-    df
-        dataframe
-    regex
-        Default None. regular expression to 'filter' list of returned columns.
-    astype
-        Default 'list'. See return options below:
-            - 'dict' returns a dictionary object
-            - 'list' returns a list object
-            - 'text' returns columns joined into a text string
-            - 'series' returns a pd.Series
-            - 'dataframe' returns a pd.DataFrame
-
-
-    Returns
-    -------
-    dictionary, list, str, pd.Series, pd.DataFrame
-    '''
-    cols = df.columns.tolist()
-
-    if regex:
-        cols = list(filter(re.compile(regex).match, cols))
-
-    if astype == 'dict':
-        return {x: x for x in cols}
-    elif astype == 'list':
-        return cols
-    elif astype == 'text':
-        return "['" +"', '".join(cols)+ "']"
-    elif astype == 'dataframe':
-        return pd.DataFrame(cols, columns = ['column_names'])
-    elif astype == 'series':
-        return pd.Series(cols, name='column_names')
-    else:
-        # note: mypy needs to see this 'dummy' catch all return statement
-        return None
-
-
 # count() {{{1
 def count(df: pd.DataFrame,
           columns: Union[str, list] = None,
@@ -673,8 +602,8 @@ def count(df: pd.DataFrame,
     return p1
 
 
-# clean_columns() {{{1
-def clean_columns(df: pd.DataFrame,
+# clean_names() {{{1
+def clean_names(df: pd.DataFrame,
                   case: str = 'snake',
                   title: bool = False) -> pd.DataFrame:
     '''Clean column names, strip blanks, lowercase, snake_case.
@@ -698,7 +627,7 @@ def clean_columns(df: pd.DataFrame,
 
     .. code-block::
 
-        df = clean_columns(df)
+        df = clean_names(df)
         df.columns.tolist()
 
         ['dupe', 'customer', 'mdm_no_to_use', 'target_name', 'public', 'material',
@@ -706,7 +635,7 @@ def clean_columns(df: pd.DataFrame,
 
     .. code-block::
 
-        df = clean_columns(df, case='report', title=True)
+        df = clean_names(df, case='report', title=True)
         df.columns.tolist()
 
         ['Dupe', 'Customer', 'Mdm No To Use', 'Target Name', 'Public', 'Material',
@@ -790,8 +719,8 @@ def distinct(df: pd.DataFrame,
              **kwargs) -> pd.DataFrame:
     '''select distinct/unique rows
 
-    This is a wrapper function rather than using e.g. df.distinct()
-    For details of args, kwargs - see help(pd.DataFrame.distinct)
+    This is a wrapper function rather than using e.g. df.drop_duplicates()
+    For details of args, kwargs - see help(pd.DataFrame.drop_duplicates)
 
     Examples
     --------
@@ -846,7 +775,7 @@ def drop(df: pd.DataFrame,
     .. code-block::
 
         df <- pd.read_csv('inputs/export.dsv', sep='\t')
-        >> clean_columns()
+        >> clean_names()
         >> trim()
         >> assign(adast = lambda x: x.adast.astype('category'),
                   adcrcd = lambda x: x.adcrcd.astype('category'),
@@ -1072,8 +1001,8 @@ def explode(df: pd.DataFrame,
     return df.explode(*args, **kwargs)
 
 
-# flatten_cols() {{{1
-def flatten_cols(df: pd.DataFrame,
+# flatten_names() {{{1
+def flatten_names(df: pd.DataFrame,
                  join_char: str = '_',
                  remove_prefix=None) -> pd.DataFrame:
     '''Flatten multi-index column headings
@@ -1092,7 +1021,7 @@ def flatten_cols(df: pd.DataFrame,
         >> assign(mike=lambda x: x.totalval1 * 50,
                   eoin=lambda x: x.totalval1 * 100)
         >> unstack()
-        >> flatten_cols()
+        >> flatten_names()
         >> select(('totalval1_East', 'totalval1_West'))
         >> head(tablefmt='plain')
 
@@ -1490,6 +1419,77 @@ def memory(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+# names() {{{1
+def names(df: pd.DataFrame,
+            regex: str = None,
+            astype: str = 'list') -> Union[str, list, dict, pd.Series, pd.DataFrame]:
+    '''show dataframe column information
+
+    This function is useful reviewing or manipulating column(s)
+
+    The dictionary output is particularly useful when composing the rename of
+    multiple columns.
+
+    Examples
+    --------
+
+    .. code-block::
+
+        import numpy as np
+        import pandas as pd
+
+        id_list = ['A', 'B', 'C', 'D', 'E']
+        s1 = pd.Series(np.random.choice(id_list, size=5), name='ids')
+
+        region_list = ['East', 'West', 'North', 'South']
+        s2 = pd.Series(np.random.choice(region_list, size=5), name='regions')
+
+        df = pd.concat([s1, s2], axis=1)
+
+        names(df, 'list')
+
+        ['ids', 'regions']
+
+
+    Parameters
+    ----------
+    df
+        dataframe
+    regex
+        Default None. regular expression to 'filter' list of returned columns.
+    astype
+        Default 'list'. See return options below:
+            - 'dict' returns a dictionary object
+            - 'list' returns a list object
+            - 'text' returns columns joined into a text string
+            - 'series' returns a pd.Series
+            - 'dataframe' returns a pd.DataFrame
+
+
+    Returns
+    -------
+    dictionary, list, str, pd.Series, pd.DataFrame
+    '''
+    cols = df.columns.tolist()
+
+    if regex:
+        cols = list(filter(re.compile(regex).match, cols))
+
+    if astype == 'dict':
+        return {x: x for x in cols}
+    elif astype == 'list':
+        return cols
+    elif astype == 'text':
+        return "['" +"', '".join(cols)+ "']"
+    elif astype == 'dataframe':
+        return pd.DataFrame(cols, columns = ['column_names'])
+    elif astype == 'series':
+        return pd.Series(cols, name='column_names')
+    else:
+        # note: mypy needs to see this 'dummy' catch all return statement
+        return None
+
+
 # non_alpha() {{{1
 def non_alpha(df: pd.DataFrame, col_name: str) -> pd.DataFrame:
     '''check for non-alphanumeric characters
@@ -1832,8 +1832,6 @@ def pivot_table(df: pd.DataFrame,
     -------
     pandas DataFrame object
     '''
-    logger.debug(args)
-    logger.debug(kwargs)
 
     if kwargs.get('index') != None:
         index = _set_grouper(df, kwargs.get('index'), freq=freq)
@@ -1984,8 +1982,8 @@ def relocate(df: pd.DataFrame,
     return sequence(new_column_sequence, index=index)
 
 
-# replace_columns {{{1
-def replace_columns(df: pd.DataFrame,
+# replace_names {{{1
+def replace_names(df: pd.DataFrame,
                         dict_: Dict,
                         info: bool = False) -> pd.DataFrame:
     """ replace column names (or partially) with dictionary values
@@ -2006,8 +2004,8 @@ def replace_columns(df: pd.DataFrame,
                     'profit', 'date', 'mth_nbr', 'mth_name', 'yr']
 
         df = pd.DataFrame(None, columns=cols)
-        df = replace_columns(df, dict_, info=False)
-        df = clean_columns(df)
+        df = replace_names(df, dict_, info=False)
+        df = clean_names(df)
 
         assert expected == list(df.columns)
 
@@ -2203,8 +2201,8 @@ def right_join(df: pd.DataFrame, *args, **kwargs) -> pd.DataFrame:
     return df.merge(*args, **kwargs)
 
 
-# rows_to_columns() {{{1
-def rows_to_columns(df: pd.DataFrame,
+# rows_to_names() {{{1
+def rows_to_names(df: pd.DataFrame,
                     start: int = 0,
                     end: int = 1,
                     delimitter: str = ' ',
@@ -2235,7 +2233,7 @@ def rows_to_columns(df: pd.DataFrame,
 
     .. code-block::
 
-        df = rows_to_columns(df, fillna=True)
+        df = rows_to_names(df, fillna=True)
         head(df, tablefmt='plain')
 
               Customer Id  Order Number      Order Qty  Item Number    Item Description
@@ -2278,7 +2276,7 @@ def rows_to_columns(df: pd.DataFrame,
     if infer_objects:
         df = df.infer_objects()
 
-    df = clean_columns(df, case='report')
+    df = clean_names(df, case='report')
 
     return df
 
@@ -2475,8 +2473,8 @@ def select(df: pd.DataFrame,
 
     return df[selected]
 
-# set_columns() {{{1
-def set_columns(df: pd.DataFrame,
+# set_names() {{{1
+def set_names(df: pd.DataFrame,
                 columns: Union[str, Any] = None) -> pd.DataFrame:
     '''set dataframe column names
 
@@ -3410,7 +3408,7 @@ def where(df: pd.DataFrame,
     .. code-block::
 
         (select(customers)
-         .pipe(clean_columns)
+         .pipe(clean_names)
          .pipe(select, ['client_code', 'establishment_type', 'address_1', 'address_2', 'town'])
          .pipe(where, 'establishment_type != 91')
          .pipe(where, "town != 'LISBOA' & establishment_type != 91"))

--- a/piper/verbs.py
+++ b/piper/verbs.py
@@ -896,8 +896,8 @@ def drop(df: pd.DataFrame,
     return df.drop(*args, **kwargs)
 
 
-# drop_columns() {{{1
-def drop_columns(df: pd.DataFrame,
+# drop_if() {{{1
+def drop_if(df: pd.DataFrame,
                  value: Union[str, int, float] = None,
                  how: str = 'all') -> pd.DataFrame:
     ''' drop columns containing blanks, zeros or na
@@ -908,7 +908,7 @@ def drop_columns(df: pd.DataFrame,
 
         %%piper
         dummy_dataframe()
-        >> drop_columns()
+        >> drop_if()
 
     Parameters
     ----------

--- a/piper/verbs.py
+++ b/piper/verbs.py
@@ -1733,7 +1733,7 @@ def overlaps(df: pd.DataFrame,
 
 
 # pivot_longer() {{{1
-# @wraps(pd.DataFrame.melt)
+@wraps(pd.DataFrame.melt)
 def pivot_longer(df: pd.DataFrame,
                  *args: Any,
                  **kwargs: Any) -> pd.DataFrame:

--- a/piper/verbs.py
+++ b/piper/verbs.py
@@ -872,11 +872,27 @@ def drop_if(df: pd.DataFrame,
 
     Examples
     --------
+
     .. code-block::
 
-        %%piper
-        dummy_dataframe()
-        >> drop_if()
+        df = dummy_dataframe()
+        head(df, tablefmt='plain')
+              zero_1    zero_2    zero_3    zero_4    zero_5  blank_1    blank_2    blank_3    blank_4    blank_5
+         0         0         0         0         0         0
+         1         0         0         0         0         0
+         2         0         0         0         0         0
+         3         0         0         0         0         0
+
+    .. code-block::
+
+        df = drop_if(df)
+        head(df, tablefmt='plain')
+              zero_1    zero_2    zero_3    zero_4    zero_5
+         0         0         0         0         0         0
+         1         0         0         0         0         0
+         2         0         0         0         0         0
+         3         0         0         0         0         0
+
 
     Parameters
     ----------
@@ -1934,6 +1950,69 @@ def relocate(df: pd.DataFrame,
     return sequence(new_column_sequence, index=index)
 
 
+# replace_columns {{{1
+def replace_columns(df: pd.DataFrame,
+                        dict_: Dict,
+                        info: bool = False) -> pd.DataFrame:
+    """ replace column names (or partially) with dictionary values
+
+
+    Examples
+    --------
+
+    .. code-block::
+
+        dict_ = { 'number$': 'nbr', 'revenue per cookie': 'unit revenue', 'cost per cookie': 'unit cost',
+              'month': 'mth', 'revenue per cookie': 'unit revenue', 'product': 'item', 'year': 'yr'}
+
+        cols = ['Country', 'Product', 'Units Sold', 'Revenue per cookie', 'Cost per cookie',
+                'Revenue', 'Cost', 'Profit', 'Date', 'Month Number', 'Month Name', 'Year']
+
+        expected = ['country','item', 'units_sold', 'unit_revenue', 'unit_cost', 'revenue', 'cost',
+                    'profit', 'date', 'mth_nbr', 'mth_name', 'yr']
+
+        df = pd.DataFrame(None, columns=cols)
+        df = replace_columns(df, dict_, info=False)
+        df = clean_columns(df)
+
+        assert expected == list(df.columns)
+
+    Parameters
+    ----------
+    df
+        a pandas dataframe
+    values
+        dictionary of from/to values (optionally) with regex values
+    info
+        Default False. If True, print replacement from/to values.
+
+    Returns
+    -------
+    a pandas dataframe
+    """
+    updated_columns = []
+    replacements = []
+
+    for x in df.columns:
+
+        for k, v in dict_.items():
+            y = re.sub(k, v, x, flags=re.I)
+            if y != x:
+                replacements.append((x, y))
+                x = y
+
+        updated_columns.append(x)
+
+    if len(replacements) > 0:
+        logger.info('|Warning| automatic column names substitutions made, for details, info=True')
+        if info:
+            repl_ = [f'{x} => {y}' for (x,y) in replacements]
+            logger.info(f'{repl_}')
+
+    df.columns = updated_columns
+
+    return df
+
 # rename() {{{1
 def rename(df: pd.DataFrame, *args, **kwargs) -> pd.DataFrame :
     '''rename dataframe col(s)
@@ -2497,69 +2576,6 @@ def str_clean_number(series: pd.Series,
 
     return series
 
-
-# str_columns_replace {{{1
-def str_columns_replace(df: pd.DataFrame,
-                        dict_: Dict,
-                        info: bool = False) -> pd.DataFrame:
-    """ replace column names (or partially) with dictionary values
-
-
-    Examples
-    --------
-
-    .. code-block::
-
-        dict_ = { 'number$': 'nbr', 'revenue per cookie': 'unit revenue', 'cost per cookie': 'unit cost',
-              'month': 'mth', 'revenue per cookie': 'unit revenue', 'product': 'item', 'year': 'yr'}
-
-        cols = ['Country', 'Product', 'Units Sold', 'Revenue per cookie', 'Cost per cookie',
-                'Revenue', 'Cost', 'Profit', 'Date', 'Month Number', 'Month Name', 'Year']
-
-        expected = ['country','item', 'units_sold', 'unit_revenue', 'unit_cost', 'revenue', 'cost',
-                    'profit', 'date', 'mth_nbr', 'mth_name', 'yr']
-
-        df = pd.DataFrame(None, columns=cols)
-        df = str_columns_replace(df, dict_, info=False)
-        df = clean_columns(df)
-
-        assert expected == list(df.columns)
-
-    Parameters
-    ----------
-    df
-        a pandas dataframe
-    values
-        dictionary of from/to values (optionally) with regex values
-    info
-        Default False. If True, print replacement from/to values.
-
-    Returns
-    -------
-    a pandas dataframe
-    """
-    updated_columns = []
-    replacements = []
-
-    for x in df.columns:
-
-        for k, v in dict_.items():
-            y = re.sub(k, v, x, flags=re.I)
-            if y != x:
-                replacements.append((x, y))
-                x = y
-
-        updated_columns.append(x)
-
-    if len(replacements) > 0:
-        logger.info('|Warning| automatic column names substitutions made, for details, info=True')
-        if info:
-            repl_ = [f'{x} => {y}' for (x,y) in replacements]
-            logger.info(f'{repl_}')
-
-    df.columns = updated_columns
-
-    return df
 
 # str_join() {{{1
 def str_join(df: pd.DataFrame,

--- a/piper/verbs.py
+++ b/piper/verbs.py
@@ -1006,9 +1006,9 @@ def duplicated(df: pd.DataFrame,
                keep: bool = False,
                sort: bool = True,
                column: str = 'duplicate',
-               loc: str = 'first',
                ref_column: str = None,
-               duplicates: bool = False) -> pd.DataFrame:
+               duplicates: bool = False,
+               loc: str = 'first') -> pd.DataFrame:
     '''locate duplicate data
 
     .. note::
@@ -1069,6 +1069,8 @@ def duplicated(df: pd.DataFrame,
 
     if sort:
         df = df.sort_values(subset)
+
+    df = relocate(df, column=column, loc=loc)
 
     return df
 
@@ -2723,7 +2725,7 @@ def str_split(df: pd.DataFrame,
             # If one of the new split columns has the same name
             # as the original column, append '_' to the split column name.
             for idx, col in enumerate(columns):
-                if col in column:
+                if col == column:
                     columns[idx] = columns[idx] + '_'
                     duplicate_column_name = True
 

--- a/piper/verbs.py
+++ b/piper/verbs.py
@@ -2173,6 +2173,7 @@ def rows_to_columns(df: pd.DataFrame,
                     end: int = 1,
                     delimitter: str = ' ',
                     title: bool = True,
+                    fillna: bool = False,
                     infer_objects: bool = True) -> pd.DataFrame:
     '''promote row(s) to column name(s)
 
@@ -2199,8 +2200,7 @@ def rows_to_columns(df: pd.DataFrame,
 
     .. code-block::
 
-        df.iloc[0] = df.iloc[0].ffill()
-        df = rows_to_columns(df)
+        df = rows_to_columns(df, fillna=True)
         head(df, tablefmt='plain')
 
               Customer Id  Order Number      Order Qty  Item Number    Item Description
@@ -2219,6 +2219,8 @@ def rows_to_columns(df: pd.DataFrame,
         character to be used to 'join' row values together. default is ' '
     title
         default False. If True, titleize column values
+    fillna
+        default False. If True, fill nan values in header row.
     infer_objects
         default True. Infer data type of resultant dataframe
 
@@ -2226,6 +2228,9 @@ def rows_to_columns(df: pd.DataFrame,
     -------
     A pandas dataframe
     '''
+    if fillna:
+        df.iloc[start] = df.iloc[start].ffill().fillna('')
+
     data = df.iloc[start].astype(str).values
     rows = range(start+1, end+1)
 

--- a/piper/verbs.py
+++ b/piper/verbs.py
@@ -800,7 +800,6 @@ def clean_columns(df: pd.DataFrame,
             columns = [x.title() for x in columns]
 
     if case in ('camel'):
-        print(columns)
         columns = [camel_case(x, title=title) for x in columns]
 
     df.columns = columns
@@ -1527,15 +1526,15 @@ def non_alpha(df: pd.DataFrame, col_name: str) -> pd.DataFrame:
 def order_by(df: pd.DataFrame, *args, **kwargs) -> pd.DataFrame:
     '''order/sequence dataframe
 
-    @__TODO__ Review mypy validation rules and update if required
-
     This is a wrapper function rather than using e.g. df.sort_values()
     For details of args, kwargs - see help(pd.DataFrame.sort_values)
 
-    The first argument and/or keyword 'by' is checked to see:
+    .. note::
 
-    - For each specified column value
-      If it starts with a minus sign, assume ascending=False
+        The first argument and/or keyword 'by' is checked to see:
+
+            - For each specified column value
+              If it starts with a minus sign, assume ascending=False
 
     Examples
     --------
@@ -2161,7 +2160,6 @@ def rows_to_columns(df: pd.DataFrame,
          2       48015346  DE-12345                 10  SW-10-2134     Screwdriver Set
          3       49512432  FR-12346                 40  YH-22-2030     Workbench
 
-
     Parameters
     ----------
     df
@@ -2176,7 +2174,6 @@ def rows_to_columns(df: pd.DataFrame,
         default False. If True, titleize column values
     infer_objects
         default True. Infer data type of resultant dataframe
-
 
     Returns
     -------
@@ -2404,7 +2401,6 @@ def set_columns(df: pd.DataFrame,
         dataframe
     columns
         column(s) values to be changed in referenced dataframe
-
 
     Returns
     -------
@@ -3132,6 +3128,13 @@ def transform(df: pd.DataFrame,
 
         If no kwargs supplied - calculates the group percentage ('g%') using
         the first index column as index key and the first column value(s).
+
+        .. note::
+
+            transform() has built-in functions:
+                - percent: calculate group % associated with index group
+                - rank: dense rank (ascending order)
+                - rank_desc: dense rank (descending order)
 
 
     Returns

--- a/piper/verbs.py
+++ b/piper/verbs.py
@@ -1733,7 +1733,7 @@ def overlaps(df: pd.DataFrame,
 
 
 # pivot_longer() {{{1
-@wraps(pd.DataFrame.melt)
+# @wraps(pd.DataFrame.melt)
 def pivot_longer(df: pd.DataFrame,
                  *args: Any,
                  **kwargs: Any) -> pd.DataFrame:
@@ -2046,7 +2046,7 @@ def replace_names(df: pd.DataFrame,
     return df
 
 # rename() {{{1
-@wraps(pd.DataFrame.rename)
+# @wraps(pd.DataFrame.rename)
 def rename(df: pd.DataFrame, *args, **kwargs) -> pd.DataFrame :
     '''rename dataframe col(s)
 
@@ -2134,7 +2134,7 @@ def rename_axis(df: pd.DataFrame, *args, **kwargs) -> pd.DataFrame :
 
 
 # reset_index() {{{1
-@wraps(pd.DataFrame.reset_index)
+# @wraps(pd.DataFrame.reset_index)
 def reset_index(df: pd.DataFrame,
           *args,
           **kwargs) -> pd.DataFrame:
@@ -2495,7 +2495,7 @@ def set_names(df: pd.DataFrame,
 
 
 # set_index() {{{1
-@wraps(pd.DataFrame.set_index)
+# @wraps(pd.DataFrame.set_index)
 def set_index(df: pd.DataFrame,
           *args,
           **kwargs) -> pd.DataFrame:
@@ -3366,7 +3366,7 @@ def transform(df: pd.DataFrame,
 
 
 # unstack() {{{1
-@wraps(pd.DataFrame.unstack)
+# @wraps(pd.DataFrame.unstack)
 def unstack(df: pd.DataFrame,
             *args,
             **kwargs) -> pd.DataFrame:
@@ -3394,7 +3394,7 @@ def unstack(df: pd.DataFrame,
 
 
 # where() {{{1
-@wraps(pd.DataFrame.query)
+# @wraps(pd.DataFrame.query)
 def where(df: pd.DataFrame,
           *args,
           **kwargs) -> pd.DataFrame:

--- a/piper/version.py
+++ b/piper/version.py
@@ -1,3 +1,3 @@
 """Version file"""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"


### PR DESCRIPTION
Highlights::

a2a4526 CLN: Renamed all column management functions to "names"
265d597 ENH: pivot_longer now accepts tuples converted to column range
2a6ca71 FIX: rows_to_columns can now handle nans in headings
8665241 ENH: Improved str_clean_number logic
9d09bbb CLN: Added docstring example to drop_if
56b00ef ENH: Added str_column_replace and str_clean_number functions
e1b710c CLN: Renamed drop_columns to drop_if
a0141c7 CLN: Added camelcase option to clean_columns
6fd9908 CLN: Refactored combine_header_rows -> rows_to_names
2e5131b FIX: Fixed bug in str_split and added back relocate logic in duplicated function
8643e4b ENH: Added notebook functions to nb.py
cc2f030 FIX: fix count to work with categorical dtypes
